### PR TITLE
Update to vite 2.8.4

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,7 +64,7 @@
     "pathe": "^0.2.0"
   },
   "peerDependencies": {
-    "vite": ">=2.0.0"
+    "vite": ">=2.8.0"
   },
   "resolutions": {
     "bin-wrapper": "npm:bin-wrapper-china",
@@ -75,6 +75,6 @@
     "@types/debug": "^4.1.7",
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^17.0.12",
-    "vite": "^2.7.13"
+    "vite": "^2.8.4"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,7 +73,7 @@ export default function (options: VitePluginImageMin = {}) {
     enforce: 'post',
     configResolved(resolvedConfig) {
       config = resolvedConfig
-      outputPath = config.build.outDir
+      outputPath = path.resolve(path.join(config.root, config.build.outDir));
 
       // get public static assets directory: https://vitejs.dev/guide/assets.html#the-public-directory
       if (typeof config.publicDir === 'string') {


### PR DESCRIPTION
Sinds 2.8.0 the output path did not resolve to the right full absolute path anymore, this fixes the issue